### PR TITLE
Fix glycol mode availability in dashboard mode selector

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -122,6 +122,7 @@ import { i18n } from "@/main.js";
 import {onBeforeUnmount, onMounted} from "vue";
 import { ref } from "vue";
 import { useTempControlStore } from "@/stores/TempControlStore.js";
+import { useExtendedSettingsStore } from "@/stores/ExtendedSettingsStore.js";
 
 const navigation = [
   { name: i18n.global.t('sitewide.sidebar_options.dashboard'), icon: HomeIcon, route_name: 'Home' },
@@ -133,12 +134,14 @@ const navigation = [
 
 const sidebarOpen = ref(false);
 const TempControlStore = useTempControlStore();  // Updated in App.vue
+const ExtendedSettingsStore = useExtendedSettingsStore();  // Updated in App.vue
 
 let intervalObject = null;
 
 onMounted(() => {
   // Retrieve initial data
   TempControlStore.getTempInfo();
+  ExtendedSettingsStore.getExtendedSettings();
 
   // Set up periodic refreshes
   intervalObject = window.setInterval(() => {


### PR DESCRIPTION
## Summary

Loads extended settings during app startup so dashboard components have access to the current glycol mode state.

This fixes the dashboard mode selector showing Fridge Constant even when glycol mode is enabled.